### PR TITLE
Add a generic equals checker…

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,0 +1,62 @@
+package shakers
+
+import (
+	"reflect"
+	"time"
+
+	check "gopkg.in/check.v1"
+)
+
+// Equaler is an interface implemented if the type has a Equal method.
+// This is used to compare struct using shakers.Equals.
+type Equaler interface {
+	Equal(Equaler) bool
+}
+
+// Equals checker verifies the obtained value is equal to the specified one.
+// It's is smart in a wait that it supports several *types* (built-in, Equaler,
+// time.Time)
+//
+//    c.Assert(myStruct, Equals, aStruct, check.Commentf("bouuuhh"))
+//    c.Assert(myTime, Equals, aTime, check.Commentf("bouuuhh"))
+//
+var Equals check.Checker = &equalChecker{
+	&check.CheckerInfo{
+		Name:   "Equals",
+		Params: []string{"obtained", "expected"},
+	},
+}
+
+type equalChecker struct {
+	*check.CheckerInfo
+}
+
+func (checker *equalChecker) Check(params []interface{}, names []string) (bool, string) {
+	return isEqual(params[0], params[1])
+}
+
+func isEqual(obtained, expected interface{}) (bool, string) {
+	switch obtained.(type) {
+	case time.Time:
+		return timeEquals(obtained, expected)
+	case Equaler:
+		return equalerEquals(obtained, expected)
+	default:
+		if reflect.TypeOf(obtained) != reflect.TypeOf(expected) {
+			return false, "obtained value and expected value have not the same type."
+		}
+		return obtained == expected, ""
+	}
+}
+
+func equalerEquals(obtained, expected interface{}) (bool, string) {
+	expectedEqualer, ok := expected.(Equaler)
+	if !ok {
+		return false, "expected value must be an Equaler - implementing Equal(Equaler)."
+	}
+	obtainedEqualer, ok := obtained.(Equaler)
+	if !ok {
+		return false, "obtained value must be an Equaler - implementing Equal(Equaler)."
+	}
+	return obtainedEqualer.Equal(expectedEqualer), ""
+}

--- a/common_test.go
+++ b/common_test.go
@@ -3,9 +3,78 @@ package shakers
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	check "gopkg.in/check.v1"
 )
+
+func init() {
+	check.Suite(&CommonCheckerS{})
+}
+
+type CommonCheckerS struct{}
+
+func (s *CommonCheckerS) TestEqualsInfo(c *check.C) {
+	testInfo(c, Equals, "Equals", []string{"obtained", "expected"})
+}
+
+func (s *CommonCheckerS) TestEqualsValidsEquals(c *check.C) {
+	myTime, err := time.Parse("2006-01-02", "2018-01-01")
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	testCheck(c, Equals, true, "", "string", "string")
+	testCheck(c, Equals, true, "", 0, 0)
+	testCheck(c, Equals, true, "", anEqualer{1}, anEqualer{1})
+	testCheck(c, Equals, true, "", myTime, myTime)
+	testCheck(c, Equals, true, "", myTime, "2018-01-01")
+	testCheck(c, Equals, true, "", myTime, "2018-01-01T00:00:00Z")
+}
+
+func (s *CommonCheckerS) TestEqualsValidsDifferent(c *check.C) {
+	myTime1, err := time.Parse("2006-01-02", "2018-01-01")
+	if err != nil {
+		c.Fatal(err)
+	}
+	myTime2, err := time.Parse("2006-01-02", "2018-01-02")
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	testCheck(c, Equals, false, "", "string", "astring")
+	testCheck(c, Equals, false, "", 0, 1)
+	testCheck(c, Equals, false, "", anEqualer{1}, anEqualer{0})
+	testCheck(c, Equals, false, "", myTime1, myTime2)
+	testCheck(c, Equals, false, "", myTime1, "2018-01-02")
+	testCheck(c, Equals, false, "", myTime1, "2018-01-02T00:00:00Z")
+}
+
+func (s *CommonCheckerS) TestEqualsInvalids(c *check.C) {
+	// Incompatible type time.Time
+	testCheck(c, Equals, false, "obtained value and expected value have not the same type.", "2015-01-01", time.Now())
+	testCheck(c, Equals, false, "expected must be a Time struct, or parseable.", time.Now(), 0)
+
+	// Incompatible type Equaler
+	testCheck(c, Equals, false, "expected value must be an Equaler - implementing Equal(Equaler).", anEqualer{0}, 0)
+
+	testCheck(c, Equals, false, "obtained value and expected value have not the same type.", 0, anEqualer{0})
+
+	// Nils
+	testCheck(c, Equals, false, "obtained value and expected value have not the same type.", nil, 0)
+	testCheck(c, Equals, false, "obtained value and expected value have not the same type.", 0, nil)
+}
+
+type anEqualer struct {
+	value int
+}
+
+func (a anEqualer) Equal(b Equaler) bool {
+	if bEqualer, ok := b.(anEqualer); ok {
+		return a.value == bEqualer.value
+	}
+	return false
+}
 
 func Test(t *testing.T) {
 	check.TestingT(t)

--- a/string_test.go
+++ b/string_test.go
@@ -10,8 +10,6 @@ func init() {
 
 type StringCheckerS struct{}
 
-var _ = check.Suite(&StringCheckerS{})
-
 func (s *StringCheckerS) TestContains(c *check.C) {
 	testInfo(c, Contains, "Contains", []string{"value", "substring"})
 

--- a/time.go
+++ b/time.go
@@ -18,7 +18,7 @@ const shortForm = "2006-01-02"
 var IsBefore check.Checker = &isBeforeChecker{
 	&check.CheckerInfo{
 		Name:   "IsBefore",
-		Params: []string{"value", "time"},
+		Params: []string{"obtained", "expected"},
 	},
 }
 
@@ -33,13 +33,13 @@ func (checker *isBeforeChecker) Check(params []interface{}, names []string) (boo
 func isBefore(value, t interface{}) (bool, string) {
 	tTime, ok := parseTime(t)
 	if !ok {
-		return false, "Time must be a Time struct, or parseable."
+		return false, "expected must be a Time struct, or parseable."
 	}
 	valueTime, valueIsTime := parseTime(value)
 	if valueIsTime {
 		return valueTime.Before(tTime), ""
 	}
-	return false, "Obtained value is not a time.Time struct or parseable as a time."
+	return false, "obtained value is not a time.Time struct or parseable as a time."
 }
 
 // IsAfter checker verifies the specified value is before the specified time.
@@ -50,7 +50,7 @@ func isBefore(value, t interface{}) (bool, string) {
 var IsAfter check.Checker = &isAfterChecker{
 	&check.CheckerInfo{
 		Name:   "IsAfter",
-		Params: []string{"value", "time"},
+		Params: []string{"obtained", "expected"},
 	},
 }
 
@@ -65,13 +65,13 @@ func (checker *isAfterChecker) Check(params []interface{}, names []string) (bool
 func isAfter(value, t interface{}) (bool, string) {
 	tTime, ok := parseTime(t)
 	if !ok {
-		return false, "Time must be a Time struct, or parseable."
+		return false, "expected must be a Time struct, or parseable."
 	}
 	valueTime, valueIsTime := parseTime(value)
 	if valueIsTime {
 		return valueTime.After(tTime), ""
 	}
-	return false, "Obtained value is not a time.Time struct or parseable as a time."
+	return false, "obtained value is not a time.Time struct or parseable as a time."
 }
 
 // IsBetween checker verifies the specified time is between the specified start
@@ -82,7 +82,7 @@ func isAfter(value, t interface{}) (bool, string) {
 var IsBetween check.Checker = &isBetweenChecker{
 	&check.CheckerInfo{
 		Name:   "IsBetween",
-		Params: []string{"value", "start", "end"},
+		Params: []string{"obtained", "start", "end"},
 	},
 }
 
@@ -97,17 +97,17 @@ func (checker *isBetweenChecker) Check(params []interface{}, names []string) (bo
 func isBetween(value, start, end interface{}) (bool, string) {
 	startTime, ok := parseTime(start)
 	if !ok {
-		return false, "Start must be a Time struct, or parseable."
+		return false, "start must be a Time struct, or parseable."
 	}
 	endTime, ok := parseTime(end)
 	if !ok {
-		return false, "End must be a Time struct, or parseable."
+		return false, "end must be a Time struct, or parseable."
 	}
 	valueTime, valueIsTime := parseTime(value)
 	if valueIsTime {
 		return valueTime.After(startTime) && valueTime.Before(endTime), ""
 	}
-	return false, "Obtained value is not a time.Time struct or parseable as a time."
+	return false, "obtained value is not a time.Time struct or parseable as a time."
 }
 
 // TimeEquals checker verifies the specified time is the equal to the expected
@@ -123,7 +123,7 @@ func isBetween(value, start, end interface{}) (bool, string) {
 var TimeEquals check.Checker = &timeEqualsChecker{
 	&check.CheckerInfo{
 		Name:   "TimeEquals",
-		Params: []string{"value", "expected"},
+		Params: []string{"obtained", "expected"},
 	},
 }
 
@@ -135,16 +135,16 @@ func (checker *timeEqualsChecker) Check(params []interface{}, names []string) (b
 	return timeEquals(params[0], params[1])
 }
 
-func timeEquals(value, expected interface{}) (bool, string) {
+func timeEquals(obtained, expected interface{}) (bool, string) {
 	expectedTime, ok := parseTime(expected)
 	if !ok {
-		return false, "Time must be a Time struct, or parseable."
+		return false, "expected must be a Time struct, or parseable."
 	}
-	valueTime, valueIsTime := parseTime(value)
+	valueTime, valueIsTime := parseTime(obtained)
 	if valueIsTime {
 		return valueTime.Equal(expectedTime), ""
 	}
-	return false, "Obtained value is not a time.Time struct or parseable as a time."
+	return false, "obtained value is not a time.Time struct or parseable as a time."
 }
 
 // TimeIgnore checker will ignore some part of the time on the encapsulated checker.

--- a/time_test.go
+++ b/time_test.go
@@ -12,676 +12,674 @@ func init() {
 
 type TimeCheckerS struct{}
 
-var _ = check.Suite(&TimeCheckerS{})
-
 type randomStruct struct {
 	foo string
 	baz int
 }
 
 func (s *TimeCheckerS) TestIsBefore(c *check.C) {
-	testInfo(c, IsBefore, "IsBefore", []string{"value", "time"})
+	testInfo(c, IsBefore, "IsBefore", []string{"obtained", "expected"})
 }
 
 func (s *TimeCheckerS) TestIsAfter(c *check.C) {
-	testInfo(c, IsAfter, "IsAfter", []string{"value", "time"})
+	testInfo(c, IsAfter, "IsAfter", []string{"obtained", "expected"})
 }
 
 func (s *TimeCheckerS) TestIsBetweenInfo(c *check.C) {
-	testInfo(c, IsBetween, "IsBetween", []string{"value", "start", "end"})
+	testInfo(c, IsBetween, "IsBetween", []string{"obtained", "start", "end"})
 }
 
 func (s *TimeCheckerS) TestTimeEquals(c *check.C) {
-	testInfo(c, TimeEquals, "TimeEquals", []string{"value", "expected"})
+	testInfo(c, TimeEquals, "TimeEquals", []string{"obtained", "expected"})
 }
 
 func (s *TimeCheckerS) TestTimeIgnore(c *check.C) {
-	testInfo(c, TimeIgnore(TimeEquals, time.Second), "TimeIgnore(TimeEquals, 1s)", []string{"value", "expected"})
-	testInfo(c, TimeIgnore(IsBefore, time.Minute), "TimeIgnore(IsBefore, 1m0s)", []string{"value", "time"})
-	testInfo(c, TimeIgnore(IsBetween, time.Hour), "TimeIgnore(IsBetween, 1h0m0s)", []string{"value", "start", "end"})
+	testInfo(c, TimeIgnore(TimeEquals, time.Second), "TimeIgnore(TimeEquals, 1s)", []string{"obtained", "expected"})
+	testInfo(c, TimeIgnore(IsBefore, time.Minute), "TimeIgnore(IsBefore, 1m0s)", []string{"obtained", "expected"})
+	testInfo(c, TimeIgnore(IsBetween, time.Hour), "TimeIgnore(IsBetween, 1h0m0s)", []string{"obtained", "start", "end"})
 }
 
 func (s *TimeCheckerS) TestIsBeforeValid(c *check.C) {
 	before := []struct {
-		value interface{}
-		t     interface{}
+		obtained interface{}
+		t        interface{}
 	}{
 		{
-			value: "2018-01-01",
-			t:     "2018-01-02",
+			obtained: "2018-01-01",
+			t:        "2018-01-02",
 		},
 		{
-			value: "2018-01-01T15:04:05Z",
-			t:     "2018-01-02T15:04:05Z",
+			obtained: "2018-01-01T15:04:05Z",
+			t:        "2018-01-02T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:03:05Z",
-			t:     "2018-01-02T15:04:05Z",
+			obtained: "2018-01-02T15:03:05Z",
+			t:        "2018-01-02T15:04:05Z",
 		},
 		{
-			value: "2018-01-01T15:04:05+07:00",
-			t:     "2018-01-02T15:04:05+07:00",
+			obtained: "2018-01-01T15:04:05+07:00",
+			t:        "2018-01-02T15:04:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:03:05+07:00",
-			t:     "2018-01-02T15:04:05+07:00",
+			obtained: "2018-01-02T15:03:05+07:00",
+			t:        "2018-01-02T15:04:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05+08:00",
-			t:     "2018-01-02T15:04:05+07:00",
+			obtained: "2018-01-02T15:04:05+08:00",
+			t:        "2018-01-02T15:04:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05-06:00",
-			t:     "2018-01-02T15:04:05-07:00",
+			obtained: "2018-01-02T15:04:05-06:00",
+			t:        "2018-01-02T15:04:05-07:00",
 		},
 		{
-			value: "2018-01-01T15:04:05.999999999Z",
-			t:     "2018-01-02T15:04:05.999999999Z",
+			obtained: "2018-01-01T15:04:05.999999999Z",
+			t:        "2018-01-02T15:04:05.999999999Z",
 		},
 		{
-			value: "2018-01-02T15:03:05.999999999Z",
-			t:     "2018-01-02T15:04:05.999999999Z",
+			obtained: "2018-01-02T15:03:05.999999999Z",
+			t:        "2018-01-02T15:04:05.999999999Z",
 		},
 		{
-			value: "2018-01-01T15:04:05.999999999+07:00",
-			t:     "2018-01-02T15:04:05.999999999+07:00",
+			obtained: "2018-01-01T15:04:05.999999999+07:00",
+			t:        "2018-01-02T15:04:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:03:05.999999999+07:00",
-			t:     "2018-01-02T15:04:05.999999999+07:00",
+			obtained: "2018-01-02T15:03:05.999999999+07:00",
+			t:        "2018-01-02T15:04:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999+08:00",
-			t:     "2018-01-02T15:04:05.999999999+07:00",
+			obtained: "2018-01-02T15:04:05.999999999+08:00",
+			t:        "2018-01-02T15:04:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-06:00",
-			t:     "2018-01-02T15:04:05.999999999-07:00",
+			obtained: "2018-01-02T15:04:05.999999999-06:00",
+			t:        "2018-01-02T15:04:05.999999999-07:00",
 		},
 		{
-			value: "01 Jan 18 15:04 MST",
-			t:     "02 Jan 18 15:04 MST",
+			obtained: "01 Jan 18 15:04 MST",
+			t:        "02 Jan 18 15:04 MST",
 		},
 		{
-			value: "01 Jan 18 15:03 MST",
-			t:     "01 Jan 18 15:04 MST",
+			obtained: "01 Jan 18 15:03 MST",
+			t:        "01 Jan 18 15:04 MST",
 		},
 		{
-			value: "01 Jan 18 15:04 +0700",
-			t:     "02 Jan 18 15:04 +0700",
+			obtained: "01 Jan 18 15:04 +0700",
+			t:        "02 Jan 18 15:04 +0700",
 		},
 		{
-			value: "01 Jan 18 15:03 +0700",
-			t:     "01 Jan 18 15:04 +0700",
+			obtained: "01 Jan 18 15:03 +0700",
+			t:        "01 Jan 18 15:04 +0700",
 		},
 		{
-			value: "01 Jan 18 15:04 +0800",
-			t:     "01 Jan 18 15:04 +0700",
+			obtained: "01 Jan 18 15:04 +0800",
+			t:        "01 Jan 18 15:04 +0700",
 		},
 		{
-			value: "01 Jan 18 15:04 -0600",
-			t:     "01 Jan 18 15:04 -0700",
+			obtained: "01 Jan 18 15:04 -0600",
+			t:        "01 Jan 18 15:04 -0700",
 		},
 	}
 	for _, d := range before {
-		testCheck(c, IsBefore, true, "", d.value, d.t)
+		testCheck(c, IsBefore, true, "", d.obtained, d.t)
 	}
 }
 
 func (s *TimeCheckerS) TestIsBeforeValidAfter(c *check.C) {
 	after := []struct {
-		value interface{}
-		t     interface{}
+		obtained interface{}
+		t        interface{}
 	}{
 		{
-			value: "2018-01-12",
-			t:     "2018-01-02",
+			obtained: "2018-01-12",
+			t:        "2018-01-02",
 		},
 		{
-			value: "2018-01-12T15:04:05Z",
-			t:     "2018-01-02T15:04:05Z",
+			obtained: "2018-01-12T15:04:05Z",
+			t:        "2018-01-02T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:05:05Z",
-			t:     "2018-01-02T15:04:05Z",
+			obtained: "2018-01-02T15:05:05Z",
+			t:        "2018-01-02T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05+06:00",
-			t:     "2018-01-02T15:04:05+07:00",
+			obtained: "2018-01-02T15:04:05+06:00",
+			t:        "2018-01-02T15:04:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999995Z",
-			t:     "2018-01-02T15:04:05.999999990Z",
+			obtained: "2018-01-02T15:04:05.999999995Z",
+			t:        "2018-01-02T15:04:05.999999990Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-07:00",
-			t:     "2018-01-02T15:04:05.999999999-06:00",
+			obtained: "2018-01-02T15:04:05.999999999-07:00",
+			t:        "2018-01-02T15:04:05.999999999-06:00",
 		},
 		{
-			value: "02 Jan 18 15:05 MST",
-			t:     "02 Jan 18 15:04 MST",
+			obtained: "02 Jan 18 15:05 MST",
+			t:        "02 Jan 18 15:04 MST",
 		},
 		{
-			value: "02 Jan 18 15:04 +0700",
-			t:     "02 Jan 18 15:04 +0800",
+			obtained: "02 Jan 18 15:04 +0700",
+			t:        "02 Jan 18 15:04 +0800",
 		},
 		{
-			value: "2018-01-02",
-			t:     "2018-01-02",
+			obtained: "2018-01-02",
+			t:        "2018-01-02",
 		},
 	}
 	for _, d := range after {
-		testCheck(c, IsBefore, false, "", d.value, d.t)
+		testCheck(c, IsBefore, false, "", d.obtained, d.t)
 	}
 }
 
 func (s *TimeCheckerS) TestIsBeforeInvalids(c *check.C) {
 	// Nils
-	testCheck(c, IsBefore, false, "Time must be a Time struct, or parseable.", time.Now(), nil)
-	testCheck(c, IsBefore, false, "Obtained value is not a time.Time struct or parseable as a time.", nil, time.Now())
+	testCheck(c, IsBefore, false, "expected must be a Time struct, or parseable.", time.Now(), nil)
+	testCheck(c, IsBefore, false, "obtained value is not a time.Time struct or parseable as a time.", nil, time.Now())
 
 	// wrong type
-	testCheck(c, IsBefore, false, "Time must be a Time struct, or parseable.", time.Now(), 0)
-	testCheck(c, IsBefore, false, "Obtained value is not a time.Time struct or parseable as a time.", 0, time.Now())
-	testCheck(c, IsBefore, false, "Time must be a Time struct, or parseable.", time.Now(), randomStruct{})
-	testCheck(c, IsBefore, false, "Obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now())
+	testCheck(c, IsBefore, false, "expected must be a Time struct, or parseable.", time.Now(), 0)
+	testCheck(c, IsBefore, false, "obtained value is not a time.Time struct or parseable as a time.", 0, time.Now())
+	testCheck(c, IsBefore, false, "expected must be a Time struct, or parseable.", time.Now(), randomStruct{})
+	testCheck(c, IsBefore, false, "obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now())
 
 	// Invalid strings
-	testCheck(c, IsBefore, false, "Time must be a Time struct, or parseable.", time.Now(), "this is not a date")
-	testCheck(c, IsBefore, false, "Obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now())
+	testCheck(c, IsBefore, false, "expected must be a Time struct, or parseable.", time.Now(), "this is not a date")
+	testCheck(c, IsBefore, false, "obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now())
 
 	// Invalids dates
-	testCheck(c, IsBefore, false, "Time must be a Time struct, or parseable.", time.Now(), "2018-31-02")
-	testCheck(c, IsBefore, false, "Obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now())
+	testCheck(c, IsBefore, false, "expected must be a Time struct, or parseable.", time.Now(), "2018-31-02")
+	testCheck(c, IsBefore, false, "obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now())
 
 }
 
 func (s *TimeCheckerS) TestIsAfterValid(c *check.C) {
 	before := []struct {
-		value interface{}
-		t     interface{}
+		obtained interface{}
+		t        interface{}
 	}{
 		{
-			value: "2018-01-02",
-			t:     "2018-01-01",
+			obtained: "2018-01-02",
+			t:        "2018-01-01",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-01T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-01T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-02T15:03:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-02T15:03:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			t:     "2018-01-01T15:04:05+07:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			t:        "2018-01-01T15:04:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			t:     "2018-01-02T15:03:05+07:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			t:        "2018-01-02T15:03:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			t:     "2018-01-02T15:04:05+08:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			t:        "2018-01-02T15:04:05+08:00",
 		},
 		{
-			value: "2018-01-02T15:04:05-07:00",
-			t:     "2018-01-02T15:04:05-06:00",
+			obtained: "2018-01-02T15:04:05-07:00",
+			t:        "2018-01-02T15:04:05-06:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999Z",
-			t:     "2018-01-01T15:04:05.999999999Z",
+			obtained: "2018-01-02T15:04:05.999999999Z",
+			t:        "2018-01-01T15:04:05.999999999Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999Z",
-			t:     "2018-01-02T15:03:05.999999999Z",
+			obtained: "2018-01-02T15:04:05.999999999Z",
+			t:        "2018-01-02T15:03:05.999999999Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999+07:00",
-			t:     "2018-01-01T15:04:05.999999999+07:00",
+			obtained: "2018-01-02T15:04:05.999999999+07:00",
+			t:        "2018-01-01T15:04:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999+07:00",
-			t:     "2018-01-02T15:03:05.999999999+07:00",
+			obtained: "2018-01-02T15:04:05.999999999+07:00",
+			t:        "2018-01-02T15:03:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999+07:00",
-			t:     "2018-01-02T15:04:05.999999999+08:00",
+			obtained: "2018-01-02T15:04:05.999999999+07:00",
+			t:        "2018-01-02T15:04:05.999999999+08:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-07:00",
-			t:     "2018-01-02T15:04:05.999999999-06:00",
+			obtained: "2018-01-02T15:04:05.999999999-07:00",
+			t:        "2018-01-02T15:04:05.999999999-06:00",
 		},
 		{
-			value: "02 Jan 18 15:04 MST",
-			t:     "01 Jan 18 15:04 MST",
+			obtained: "02 Jan 18 15:04 MST",
+			t:        "01 Jan 18 15:04 MST",
 		},
 		{
-			value: "01 Jan 18 15:04 MST",
-			t:     "01 Jan 18 15:03 MST",
+			obtained: "01 Jan 18 15:04 MST",
+			t:        "01 Jan 18 15:03 MST",
 		},
 		{
-			value: "02 Jan 18 15:04 +0700",
-			t:     "01 Jan 18 15:04 +0700",
+			obtained: "02 Jan 18 15:04 +0700",
+			t:        "01 Jan 18 15:04 +0700",
 		},
 		{
-			value: "01 Jan 18 15:04 +0700",
-			t:     "01 Jan 18 15:03 +0700",
+			obtained: "01 Jan 18 15:04 +0700",
+			t:        "01 Jan 18 15:03 +0700",
 		},
 		{
-			value: "01 Jan 18 15:04 +0700",
-			t:     "01 Jan 18 15:04 +0800",
+			obtained: "01 Jan 18 15:04 +0700",
+			t:        "01 Jan 18 15:04 +0800",
 		},
 		{
-			value: "01 Jan 18 15:04 -0700",
-			t:     "01 Jan 18 15:04 -0600",
+			obtained: "01 Jan 18 15:04 -0700",
+			t:        "01 Jan 18 15:04 -0600",
 		},
 	}
 	for _, d := range before {
-		testCheck(c, IsAfter, true, "", d.value, d.t)
+		testCheck(c, IsAfter, true, "", d.obtained, d.t)
 	}
 }
 
 func (s *TimeCheckerS) TestIsAfterValidBefore(c *check.C) {
 	after := []struct {
-		value interface{}
-		t     interface{}
+		obtained interface{}
+		t        interface{}
 	}{
 		{
-			value: "2018-01-02",
-			t:     "2018-01-12",
+			obtained: "2018-01-02",
+			t:        "2018-01-12",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-12T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-12T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-02T15:05:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-02T15:05:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			t:     "2018-01-02T15:04:05+06:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			t:        "2018-01-02T15:04:05+06:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999990Z",
-			t:     "2018-01-02T15:04:05.999999995Z",
+			obtained: "2018-01-02T15:04:05.999999990Z",
+			t:        "2018-01-02T15:04:05.999999995Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-06:00",
-			t:     "2018-01-02T15:04:05.999999999-07:00",
+			obtained: "2018-01-02T15:04:05.999999999-06:00",
+			t:        "2018-01-02T15:04:05.999999999-07:00",
 		},
 		{
-			value: "02 Jan 18 15:04 MST",
-			t:     "02 Jan 18 15:05 MST",
+			obtained: "02 Jan 18 15:04 MST",
+			t:        "02 Jan 18 15:05 MST",
 		},
 		{
-			value: "02 Jan 18 15:04 +0800",
-			t:     "02 Jan 18 15:04 +0700",
+			obtained: "02 Jan 18 15:04 +0800",
+			t:        "02 Jan 18 15:04 +0700",
 		},
 		{
-			value: "2018-01-02",
-			t:     "2018-01-02",
+			obtained: "2018-01-02",
+			t:        "2018-01-02",
 		},
 	}
 	for _, d := range after {
-		testCheck(c, IsAfter, false, "", d.value, d.t)
+		testCheck(c, IsAfter, false, "", d.obtained, d.t)
 	}
 }
 
 func (s *TimeCheckerS) TestIsAfterInvalids(c *check.C) {
 	// Nils
-	testCheck(c, IsAfter, false, "Time must be a Time struct, or parseable.", time.Now(), nil)
-	testCheck(c, IsAfter, false, "Obtained value is not a time.Time struct or parseable as a time.", nil, time.Now())
+	testCheck(c, IsAfter, false, "expected must be a Time struct, or parseable.", time.Now(), nil)
+	testCheck(c, IsAfter, false, "obtained value is not a time.Time struct or parseable as a time.", nil, time.Now())
 
 	// wrong type
-	testCheck(c, IsAfter, false, "Time must be a Time struct, or parseable.", time.Now(), 0)
-	testCheck(c, IsAfter, false, "Obtained value is not a time.Time struct or parseable as a time.", 0, time.Now())
-	testCheck(c, IsAfter, false, "Time must be a Time struct, or parseable.", time.Now(), randomStruct{})
-	testCheck(c, IsAfter, false, "Obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now())
+	testCheck(c, IsAfter, false, "expected must be a Time struct, or parseable.", time.Now(), 0)
+	testCheck(c, IsAfter, false, "obtained value is not a time.Time struct or parseable as a time.", 0, time.Now())
+	testCheck(c, IsAfter, false, "expected must be a Time struct, or parseable.", time.Now(), randomStruct{})
+	testCheck(c, IsAfter, false, "obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now())
 
 	// Invalid strings
-	testCheck(c, IsAfter, false, "Time must be a Time struct, or parseable.", time.Now(), "this is not a date")
-	testCheck(c, IsAfter, false, "Obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now())
+	testCheck(c, IsAfter, false, "expected must be a Time struct, or parseable.", time.Now(), "this is not a date")
+	testCheck(c, IsAfter, false, "obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now())
 
 	// Invalids dates
-	testCheck(c, IsAfter, false, "Time must be a Time struct, or parseable.", time.Now(), "2018-31-02")
-	testCheck(c, IsAfter, false, "Obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now())
+	testCheck(c, IsAfter, false, "expected must be a Time struct, or parseable.", time.Now(), "2018-31-02")
+	testCheck(c, IsAfter, false, "obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now())
 
 }
 
 func (s *TimeCheckerS) TestIsBetweenValidBetween(c *check.C) {
 	between := []struct {
-		value interface{}
-		start interface{}
-		end   interface{}
+		obtained interface{}
+		start    interface{}
+		end      interface{}
 	}{
 		{
-			value: "2018-01-02",
-			start: "2018-01-01",
-			end:   "2018-01-03",
+			obtained: "2018-01-02",
+			start:    "2018-01-01",
+			end:      "2018-01-03",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			start: "2018-01-01T15:04:05Z",
-			end:   "2018-01-03T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			start:    "2018-01-01T15:04:05Z",
+			end:      "2018-01-03T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			start: "2018-01-02T15:03:05Z",
-			end:   "2018-01-02T15:05:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			start:    "2018-01-02T15:03:05Z",
+			end:      "2018-01-02T15:05:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			start: "2018-01-01T15:04:05+07:00",
-			end:   "2018-01-03T15:04:05+07:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			start:    "2018-01-01T15:04:05+07:00",
+			end:      "2018-01-03T15:04:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			start: "2018-01-02T15:03:05+07:00",
-			end:   "2018-01-02T15:05:05+07:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			start:    "2018-01-02T15:03:05+07:00",
+			end:      "2018-01-02T15:05:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			start: "2018-01-02T15:04:05+08:00",
-			end:   "2018-01-02T15:04:05+06:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			start:    "2018-01-02T15:04:05+08:00",
+			end:      "2018-01-02T15:04:05+06:00",
 		},
 		{
-			value: "2018-01-02T15:04:05-07:00",
-			start: "2018-01-02T15:04:05-06:00",
-			end:   "2018-01-02T15:04:05-08:00",
+			obtained: "2018-01-02T15:04:05-07:00",
+			start:    "2018-01-02T15:04:05-06:00",
+			end:      "2018-01-02T15:04:05-08:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999Z",
-			start: "2018-01-01T15:04:05.999999999Z",
-			end:   "2018-01-03T15:04:05.999999999Z",
+			obtained: "2018-01-02T15:04:05.999999999Z",
+			start:    "2018-01-01T15:04:05.999999999Z",
+			end:      "2018-01-03T15:04:05.999999999Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999Z",
-			start: "2018-01-02T15:03:05.999999999Z",
-			end:   "2018-01-02T15:05:05.999999999Z",
+			obtained: "2018-01-02T15:04:05.999999999Z",
+			start:    "2018-01-02T15:03:05.999999999Z",
+			end:      "2018-01-02T15:05:05.999999999Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999+07:00",
-			start: "2018-01-01T15:04:05.999999999+07:00",
-			end:   "2018-01-03T15:04:05.999999999+07:00",
+			obtained: "2018-01-02T15:04:05.999999999+07:00",
+			start:    "2018-01-01T15:04:05.999999999+07:00",
+			end:      "2018-01-03T15:04:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999+07:00",
-			start: "2018-01-02T15:03:05.999999999+07:00",
-			end:   "2018-01-02T15:05:05.999999999+07:00",
+			obtained: "2018-01-02T15:04:05.999999999+07:00",
+			start:    "2018-01-02T15:03:05.999999999+07:00",
+			end:      "2018-01-02T15:05:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999+07:00",
-			start: "2018-01-02T15:04:05.999999999+08:00",
-			end:   "2018-01-02T15:04:05.999999999+06:00",
+			obtained: "2018-01-02T15:04:05.999999999+07:00",
+			start:    "2018-01-02T15:04:05.999999999+08:00",
+			end:      "2018-01-02T15:04:05.999999999+06:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-07:00",
-			start: "2018-01-02T15:04:05.999999999-06:00",
-			end:   "2018-01-02T15:04:05.999999999-08:00",
+			obtained: "2018-01-02T15:04:05.999999999-07:00",
+			start:    "2018-01-02T15:04:05.999999999-06:00",
+			end:      "2018-01-02T15:04:05.999999999-08:00",
 		},
 		{
-			value: "02 Jan 18 15:04 MST",
-			start: "01 Jan 18 15:04 MST",
-			end:   "03 Jan 18 15:04 MST",
+			obtained: "02 Jan 18 15:04 MST",
+			start:    "01 Jan 18 15:04 MST",
+			end:      "03 Jan 18 15:04 MST",
 		},
 		{
-			value: "01 Jan 18 15:04 MST",
-			start: "01 Jan 18 15:03 MST",
-			end:   "01 Jan 18 15:05 MST",
+			obtained: "01 Jan 18 15:04 MST",
+			start:    "01 Jan 18 15:03 MST",
+			end:      "01 Jan 18 15:05 MST",
 		},
 		{
-			value: "02 Jan 18 15:04 +0700",
-			start: "01 Jan 18 15:04 +0700",
-			end:   "03 Jan 18 15:04 +0700",
+			obtained: "02 Jan 18 15:04 +0700",
+			start:    "01 Jan 18 15:04 +0700",
+			end:      "03 Jan 18 15:04 +0700",
 		},
 		{
-			value: "01 Jan 18 15:04 +0700",
-			start: "01 Jan 18 15:03 +0700",
-			end:   "01 Jan 18 15:05 +0700",
+			obtained: "01 Jan 18 15:04 +0700",
+			start:    "01 Jan 18 15:03 +0700",
+			end:      "01 Jan 18 15:05 +0700",
 		},
 		{
-			value: "01 Jan 18 15:04 +0700",
-			start: "01 Jan 18 15:04 +0800",
-			end:   "01 Jan 18 15:04 +0600",
+			obtained: "01 Jan 18 15:04 +0700",
+			start:    "01 Jan 18 15:04 +0800",
+			end:      "01 Jan 18 15:04 +0600",
 		},
 		{
-			value: "01 Jan 18 15:04 -0700",
-			start: "01 Jan 18 15:04 -0600",
-			end:   "01 Jan 18 15:04 -0800",
+			obtained: "01 Jan 18 15:04 -0700",
+			start:    "01 Jan 18 15:04 -0600",
+			end:      "01 Jan 18 15:04 -0800",
 		},
 	}
 	for _, d := range between {
-		testCheck(c, IsBetween, true, "", d.value, d.start, d.end)
+		testCheck(c, IsBetween, true, "", d.obtained, d.start, d.end)
 	}
 }
 
 func (s *TimeCheckerS) TestIsBetweenValidOutside(c *check.C) {
 	outside := []struct {
-		value interface{}
-		start interface{}
-		end   interface{}
+		obtained interface{}
+		start    interface{}
+		end      interface{}
 	}{
 		{
-			value: "2018-01-02",
-			start: "2018-01-12",
-			end:   "2018-01-22",
+			obtained: "2018-01-02",
+			start:    "2018-01-12",
+			end:      "2018-01-22",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			start: "2018-01-12T15:04:05Z",
-			end:   "2018-01-22T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			start:    "2018-01-12T15:04:05Z",
+			end:      "2018-01-22T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			start: "2018-01-02T15:05:05Z",
-			end:   "2018-01-02T15:06:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			start:    "2018-01-02T15:05:05Z",
+			end:      "2018-01-02T15:06:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			start: "2018-01-02T15:04:05+06:00",
-			end:   "2018-01-02T15:04:05+05:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			start:    "2018-01-02T15:04:05+06:00",
+			end:      "2018-01-02T15:04:05+05:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999990Z",
-			start: "2018-01-02T15:04:05.999999995Z",
-			end:   "2018-01-02T15:04:05.999999996Z",
+			obtained: "2018-01-02T15:04:05.999999990Z",
+			start:    "2018-01-02T15:04:05.999999995Z",
+			end:      "2018-01-02T15:04:05.999999996Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-06:00",
-			start: "2018-01-02T15:04:05.999999999-07:00",
-			end:   "2018-01-02T15:04:05.999999999-08:00",
+			obtained: "2018-01-02T15:04:05.999999999-06:00",
+			start:    "2018-01-02T15:04:05.999999999-07:00",
+			end:      "2018-01-02T15:04:05.999999999-08:00",
 		},
 		{
-			value: "02 Jan 18 15:04 MST",
-			start: "02 Jan 18 15:05 MST",
-			end:   "02 Jan 18 15:06 MST",
+			obtained: "02 Jan 18 15:04 MST",
+			start:    "02 Jan 18 15:05 MST",
+			end:      "02 Jan 18 15:06 MST",
 		},
 		{
-			value: "02 Jan 18 15:04 +0700",
-			start: "02 Jan 18 15:04 +0800",
-			end:   "02 Jan 18 15:04 +0900",
+			obtained: "02 Jan 18 15:04 +0700",
+			start:    "02 Jan 18 15:04 +0800",
+			end:      "02 Jan 18 15:04 +0900",
 		},
 		{
-			value: "2018-01-02",
-			start: "2018-01-02",
-			end:   "2018-01-10",
+			obtained: "2018-01-02",
+			start:    "2018-01-02",
+			end:      "2018-01-10",
 		},
 		{
-			value: "2018-01-02",
-			start: "2018-01-01",
-			end:   "2018-01-02",
+			obtained: "2018-01-02",
+			start:    "2018-01-01",
+			end:      "2018-01-02",
 		},
 		{
-			value: "2018-01-02",
-			start: "2018-01-02",
-			end:   "2018-01-02",
+			obtained: "2018-01-02",
+			start:    "2018-01-02",
+			end:      "2018-01-02",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			start: "2018-01-02T15:03:05Z",
-			end:   "2018-01-02T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			start:    "2018-01-02T15:03:05Z",
+			end:      "2018-01-02T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			start: "2018-01-02T15:04:05Z",
-			end:   "2018-01-02T15:05:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			start:    "2018-01-02T15:04:05Z",
+			end:      "2018-01-02T15:05:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			start: "2018-01-02T15:04:05Z",
-			end:   "2018-01-02T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			start:    "2018-01-02T15:04:05Z",
+			end:      "2018-01-02T15:04:05Z",
 		},
 	}
 	for _, d := range outside {
-		testCheck(c, IsBetween, false, "", d.value, d.start, d.end)
+		testCheck(c, IsBetween, false, "", d.obtained, d.start, d.end)
 	}
 }
 
 func (s *TimeCheckerS) TestIsBetweenInvalids(c *check.C) {
 	// Nils
-	testCheck(c, IsBetween, false, "Start must be a Time struct, or parseable.", time.Now(), nil, time.Now())
-	testCheck(c, IsBetween, false, "End must be a Time struct, or parseable.", time.Now(), time.Now(), nil)
-	testCheck(c, IsBetween, false, "Obtained value is not a time.Time struct or parseable as a time.", nil, time.Now(), time.Now())
+	testCheck(c, IsBetween, false, "start must be a Time struct, or parseable.", time.Now(), nil, time.Now())
+	testCheck(c, IsBetween, false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), nil)
+	testCheck(c, IsBetween, false, "obtained value is not a time.Time struct or parseable as a time.", nil, time.Now(), time.Now())
 
 	// wrong type
-	testCheck(c, IsBetween, false, "Start must be a Time struct, or parseable.", time.Now(), 0, time.Now())
-	testCheck(c, IsBetween, false, "End must be a Time struct, or parseable.", time.Now(), time.Now(), 0)
-	testCheck(c, IsBetween, false, "Obtained value is not a time.Time struct or parseable as a time.", 0, time.Now(), time.Now())
-	testCheck(c, IsBetween, false, "Start must be a Time struct, or parseable.", time.Now(), randomStruct{}, time.Now())
-	testCheck(c, IsBetween, false, "End must be a Time struct, or parseable.", time.Now(), time.Now(), randomStruct{})
-	testCheck(c, IsBetween, false, "Obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now(), time.Now())
+	testCheck(c, IsBetween, false, "start must be a Time struct, or parseable.", time.Now(), 0, time.Now())
+	testCheck(c, IsBetween, false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), 0)
+	testCheck(c, IsBetween, false, "obtained value is not a time.Time struct or parseable as a time.", 0, time.Now(), time.Now())
+	testCheck(c, IsBetween, false, "start must be a Time struct, or parseable.", time.Now(), randomStruct{}, time.Now())
+	testCheck(c, IsBetween, false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), randomStruct{})
+	testCheck(c, IsBetween, false, "obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now(), time.Now())
 
 	// Invalid strings
-	testCheck(c, IsBetween, false, "Start must be a Time struct, or parseable.", time.Now(), "this is not a date", time.Now())
-	testCheck(c, IsBetween, false, "End must be a Time struct, or parseable.", time.Now(), time.Now(), "this is not a date")
-	testCheck(c, IsBetween, false, "Obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now(), time.Now())
+	testCheck(c, IsBetween, false, "start must be a Time struct, or parseable.", time.Now(), "this is not a date", time.Now())
+	testCheck(c, IsBetween, false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), "this is not a date")
+	testCheck(c, IsBetween, false, "obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now(), time.Now())
 
 	// Invalids dates
-	testCheck(c, IsBetween, false, "Start must be a Time struct, or parseable.", time.Now(), "2018-31-02", time.Now())
-	testCheck(c, IsBetween, false, "End must be a Time struct, or parseable.", time.Now(), time.Now(), "2018-31-02")
-	testCheck(c, IsBetween, false, "Obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now(), time.Now())
+	testCheck(c, IsBetween, false, "start must be a Time struct, or parseable.", time.Now(), "2018-31-02", time.Now())
+	testCheck(c, IsBetween, false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), "2018-31-02")
+	testCheck(c, IsBetween, false, "obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now(), time.Now())
 
 }
 
 func (s *TimeCheckerS) TestTimeEqualsValid(c *check.C) {
 	before := []struct {
-		value interface{}
-		t     interface{}
+		obtained interface{}
+		t        interface{}
 	}{
 		{
-			value: "2018-01-02",
-			t:     "2018-01-02",
+			obtained: "2018-01-02",
+			t:        "2018-01-02",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-02T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-02T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-02T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-02T15:04:05Z",
 		},
 		{
-			value: "2018-01-01T15:04:05+07:00",
-			t:     "2018-01-01T15:04:05+07:00",
+			obtained: "2018-01-01T15:04:05+07:00",
+			t:        "2018-01-01T15:04:05+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05-07:00",
-			t:     "2018-01-02T15:04:05-07:00",
+			obtained: "2018-01-02T15:04:05-07:00",
+			t:        "2018-01-02T15:04:05-07:00",
 		},
 		{
-			value: "2018-01-01T15:04:05.999999999Z",
-			t:     "2018-01-01T15:04:05.999999999Z",
+			obtained: "2018-01-01T15:04:05.999999999Z",
+			t:        "2018-01-01T15:04:05.999999999Z",
 		},
 		{
-			value: "2018-01-01T15:04:05.999999999+07:00",
-			t:     "2018-01-01T15:04:05.999999999+07:00",
+			obtained: "2018-01-01T15:04:05.999999999+07:00",
+			t:        "2018-01-01T15:04:05.999999999+07:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-07:00",
-			t:     "2018-01-02T15:04:05.999999999-07:00",
+			obtained: "2018-01-02T15:04:05.999999999-07:00",
+			t:        "2018-01-02T15:04:05.999999999-07:00",
 		},
 		{
-			value: "01 Jan 18 15:04 MST",
-			t:     "01 Jan 18 15:04 MST",
+			obtained: "01 Jan 18 15:04 MST",
+			t:        "01 Jan 18 15:04 MST",
 		},
 		{
-			value: "01 Jan 18 15:04 +0700",
-			t:     "01 Jan 18 15:04 +0700",
+			obtained: "01 Jan 18 15:04 +0700",
+			t:        "01 Jan 18 15:04 +0700",
 		},
 		{
-			value: "01 Jan 18 15:04 -0700",
-			t:     "01 Jan 18 15:04 -0700",
+			obtained: "01 Jan 18 15:04 -0700",
+			t:        "01 Jan 18 15:04 -0700",
 		},
 	}
 	for _, d := range before {
-		testCheck(c, TimeEquals, true, "", d.value, d.t)
+		testCheck(c, TimeEquals, true, "", d.obtained, d.t)
 	}
 }
 
 func (s *TimeCheckerS) TestTimeEqualsDifferent(c *check.C) {
 	after := []struct {
-		value interface{}
-		t     interface{}
+		obtained interface{}
+		t        interface{}
 	}{
 		{
-			value: "2018-01-02",
-			t:     "2018-01-12",
+			obtained: "2018-01-02",
+			t:        "2018-01-12",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-12T15:04:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-12T15:04:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05Z",
-			t:     "2018-01-02T15:05:05Z",
+			obtained: "2018-01-02T15:04:05Z",
+			t:        "2018-01-02T15:05:05Z",
 		},
 		{
-			value: "2018-01-02T15:04:05+07:00",
-			t:     "2018-01-02T15:04:05+06:00",
+			obtained: "2018-01-02T15:04:05+07:00",
+			t:        "2018-01-02T15:04:05+06:00",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999990Z",
-			t:     "2018-01-02T15:04:05.999999995Z",
+			obtained: "2018-01-02T15:04:05.999999990Z",
+			t:        "2018-01-02T15:04:05.999999995Z",
 		},
 		{
-			value: "2018-01-02T15:04:05.999999999-06:00",
-			t:     "2018-01-02T15:04:05.999999999-07:00",
+			obtained: "2018-01-02T15:04:05.999999999-06:00",
+			t:        "2018-01-02T15:04:05.999999999-07:00",
 		},
 		{
-			value: "02 Jan 18 15:04 MST",
-			t:     "02 Jan 18 15:05 MST",
+			obtained: "02 Jan 18 15:04 MST",
+			t:        "02 Jan 18 15:05 MST",
 		},
 		{
-			value: "02 Jan 18 15:04 +0800",
-			t:     "02 Jan 18 15:04 +0700",
+			obtained: "02 Jan 18 15:04 +0800",
+			t:        "02 Jan 18 15:04 +0700",
 		},
 	}
 	for _, d := range after {
-		testCheck(c, TimeEquals, false, "", d.value, d.t)
+		testCheck(c, TimeEquals, false, "", d.obtained, d.t)
 	}
 }
 
 func (s *TimeCheckerS) TestTimeEqualsInvalids(c *check.C) {
 	// Nils
-	testCheck(c, TimeEquals, false, "Time must be a Time struct, or parseable.", time.Now(), nil)
-	testCheck(c, TimeEquals, false, "Obtained value is not a time.Time struct or parseable as a time.", nil, time.Now())
+	testCheck(c, TimeEquals, false, "expected must be a Time struct, or parseable.", time.Now(), nil)
+	testCheck(c, TimeEquals, false, "obtained value is not a time.Time struct or parseable as a time.", nil, time.Now())
 
 	// wrong type
-	testCheck(c, TimeEquals, false, "Time must be a Time struct, or parseable.", time.Now(), 0)
-	testCheck(c, TimeEquals, false, "Obtained value is not a time.Time struct or parseable as a time.", 0, time.Now())
-	testCheck(c, TimeEquals, false, "Time must be a Time struct, or parseable.", time.Now(), randomStruct{})
-	testCheck(c, TimeEquals, false, "Obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now())
+	testCheck(c, TimeEquals, false, "expected must be a Time struct, or parseable.", time.Now(), 0)
+	testCheck(c, TimeEquals, false, "obtained value is not a time.Time struct or parseable as a time.", 0, time.Now())
+	testCheck(c, TimeEquals, false, "expected must be a Time struct, or parseable.", time.Now(), randomStruct{})
+	testCheck(c, TimeEquals, false, "obtained value is not a time.Time struct or parseable as a time.", randomStruct{}, time.Now())
 
 	// Invalid strings
-	testCheck(c, TimeEquals, false, "Time must be a Time struct, or parseable.", time.Now(), "this is not a date")
-	testCheck(c, TimeEquals, false, "Obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now())
+	testCheck(c, TimeEquals, false, "expected must be a Time struct, or parseable.", time.Now(), "this is not a date")
+	testCheck(c, TimeEquals, false, "obtained value is not a time.Time struct or parseable as a time.", "this is not a date", time.Now())
 
 	// Invalids dates
-	testCheck(c, TimeEquals, false, "Time must be a Time struct, or parseable.", time.Now(), "2018-31-02")
-	testCheck(c, TimeEquals, false, "Obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now())
+	testCheck(c, TimeEquals, false, "expected must be a Time struct, or parseable.", time.Now(), "2018-31-02")
+	testCheck(c, TimeEquals, false, "obtained value is not a time.Time struct or parseable as a time.", "2018-31-02", time.Now())
 
 }
 
@@ -704,43 +702,43 @@ func (s *TimeCheckerS) TestTimeIgnoreValids(c *check.C) {
 func (s *TimeCheckerS) TestTimeIgnoreInvalids(c *check.C) {
 	// Nils
 	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "expected must be a Time struct, or parseable.", time.Now(), nil)
-	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "value must be a Time struct, or parseable.", nil, time.Now())
+	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "obtained must be a Time struct, or parseable.", nil, time.Now())
 
 	// wrong type
 	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "expected must be a Time struct, or parseable.", time.Now(), 0)
-	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "value must be a Time struct, or parseable.", 0, time.Now())
+	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "obtained must be a Time struct, or parseable.", 0, time.Now())
 	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "expected must be a Time struct, or parseable.", time.Now(), randomStruct{})
-	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "value must be a Time struct, or parseable.", randomStruct{}, time.Now())
+	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "obtained must be a Time struct, or parseable.", randomStruct{}, time.Now())
 
 	// Invalid strings
 	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "expected must be a Time struct, or parseable.", time.Now(), "this is not a date")
-	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "value must be a Time struct, or parseable.", "this is not a date", time.Now())
+	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "obtained must be a Time struct, or parseable.", "this is not a date", time.Now())
 
 	// Invalids dates
 	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "expected must be a Time struct, or parseable.", time.Now(), "2018-31-02")
-	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "value must be a Time struct, or parseable.", "2018-31-02", time.Now())
+	testCheck(c, TimeIgnore(TimeEquals, time.Hour), false, "obtained must be a Time struct, or parseable.", "2018-31-02", time.Now())
 
 	// Nils
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "start must be a Time struct, or parseable.", time.Now(), nil, time.Now())
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), nil)
-	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "value must be a Time struct, or parseable.", nil, time.Now(), time.Now())
+	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "obtained must be a Time struct, or parseable.", nil, time.Now(), time.Now())
 
 	// wrong type
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "start must be a Time struct, or parseable.", time.Now(), 0, time.Now())
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), 0)
-	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "value must be a Time struct, or parseable.", 0, time.Now(), time.Now())
+	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "obtained must be a Time struct, or parseable.", 0, time.Now(), time.Now())
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "start must be a Time struct, or parseable.", time.Now(), randomStruct{}, time.Now())
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), randomStruct{})
-	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "value must be a Time struct, or parseable.", randomStruct{}, time.Now(), time.Now())
+	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "obtained must be a Time struct, or parseable.", randomStruct{}, time.Now(), time.Now())
 
 	// Invalid strings
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "start must be a Time struct, or parseable.", time.Now(), "this is not a date", time.Now())
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), "this is not a date")
-	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "value must be a Time struct, or parseable.", "this is not a date", time.Now(), time.Now())
+	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "obtained must be a Time struct, or parseable.", "this is not a date", time.Now(), time.Now())
 
 	// Invalids dates
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "start must be a Time struct, or parseable.", time.Now(), "2018-31-02", time.Now())
 	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "end must be a Time struct, or parseable.", time.Now(), time.Now(), "2018-31-02")
-	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "value must be a Time struct, or parseable.", "2018-31-02", time.Now(), time.Now())
+	testCheck(c, TimeIgnore(IsBetween, time.Hour), false, "obtained must be a Time struct, or parseable.", "2018-31-02", time.Now(), time.Now())
 
 }


### PR DESCRIPTION
… and refactor/clean a bit the times checkers.

``` go
c.Assert(myTime, Equals, "2018-01-01", check.Commentf("It should works !"))
c.Assert(1, Equals, 1, check.Commentf("It should works !"))
// myStruct && myOtherStruct implementing Equaler
c.Assert(myStruct, Equals, myOtherStruct, check.Commentf("It should works !"))
```

/cc @runcom @tiborvass
